### PR TITLE
Fix asset paths for GitHub Pages by setting base path in Vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,5 @@ import react from '@vitejs/plugin-react';
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: '/Apartment-Hunt-AI/',
 });


### PR DESCRIPTION
Added the base option in vite.config.ts to ensure that all built assets load correctly on GitHub Pages under the repository name path. This fixes broken CSS and JS loading issues on the live site.