### PR TITLE
Add responsive Sign-up page with Button and Input components

### DIFF
--- a/src/Components/Layout/Navbar.tsx
+++ b/src/Components/Layout/Navbar.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import Button from '../UI/Button';
 
 const Navbar = () => {
   return (
@@ -13,13 +14,11 @@ const Navbar = () => {
             <span className="text-blue-500">AI</span>
           </Link>
           <div className="">
-            <Link
-              to="/Apartment-Hunt-AI"
-              type="button"
-              className="bg-blue-500 hover:bg-blue-400 active:bg-blue-300 text-white text-sm sm:text-md md:text-lg font-semibold py-1 px-2 sm:py-1.5 sm:px-3 md:py-2 md:px-4 rounded shadow-md hover:shadow-lg active:shadow-inner transition-all duration-150 ease-in-out"
-            >
-              Sign in
-            </Link>
+            <Button
+              to={'/Apartment-Hunt-AI'}
+              children={'Sign in'}
+              variant={'blue'}
+            />
           </div>
         </div>
       </div>

--- a/src/Components/Pages/Register.tsx
+++ b/src/Components/Pages/Register.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import Button from '../UI/Button';
+import Input from '../UI/Input';
+import { FcGoogle } from 'react-icons/fc';
+
+const Signup = () => {
+  type FormData = {
+    name: string;
+    email: string;
+    password: string;
+  };
+  const [formData, setFormData] = useState<FormData>({
+    name: '',
+    email: '',
+    password: '',
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    console.log('Form submitted:', formData);
+    // TODO: send to backend API
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-3 sm:px-0">
+      <div className="w-full max-w-md flex flex-col items-center bg-white p-8 rounded-2xl shadow-lg">
+        <Button to={'/Apartment-Hunt-AI'} variant={'white'}>
+          <span className="flex items-center space-x-3">
+            <span className="text-2xl">
+              <FcGoogle />
+            </span>
+            <span>Continue with Google</span>
+          </span>
+        </Button>
+        <p className="text-md sm:text-lg md:text-xl m-5">OR</p>
+
+        <form onSubmit={handleSubmit} className="w-full space-y-4">
+          <Input
+            type="email"
+            placeholder="Email"
+            name="email"
+            value={formData.email}
+            onChange={handleChange}
+          />
+          {formData.email && (
+            <Input
+              type="password"
+              placeholder="Password"
+              name="password"
+              value={formData.password}
+              onChange={handleChange}
+            />
+          )}
+
+          <div className="w-full">
+            <Button variant={'blue'}>Sign up</Button>
+          </div>
+        </form>
+
+        <p className="text-sm text-center mt-4">
+          Already have an account?{' '}
+          <Link
+            to="/Apartment-Hunt-AI"
+            className="text-blue-600 hover:underline"
+          >
+            Sign in
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default Signup;

--- a/src/Components/UI/Button.tsx
+++ b/src/Components/UI/Button.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+type Prop = {
+  to?: string;
+  children: React.ReactNode;
+  variant: 'blue' | 'white';
+};
+
+const styleClasses: Record<string, string> = {
+  base: 'w-full block flex justify-center text-sm sm:text-md md:text-lg font-semibold py-1 px-2 sm:py-1.5 sm:px-3 md:py-2 md:px-4 rounded-xl',
+  blue: 'bg-blue-500 hover:bg-blue-400 active:bg-blue-300 text-white shadow-md active:shadow-inner transition-all duration-150 ease-in-out',
+  white: 'text-gray-500 border border-gray-200 hover:bg-blue-100',
+};
+
+const Button = ({ to, children, variant }: Prop) => {
+  return (
+    <div className="w-full">
+      {to ? (
+        <Link
+          to={to}
+          className={`${styleClasses.base} ${styleClasses[variant]}`}
+        >
+          {children}
+        </Link>
+      ) : (
+        <button className={`${styleClasses.base} ${styleClasses[variant]}`}>
+          {children}
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default Button;

--- a/src/Components/UI/Input.tsx
+++ b/src/Components/UI/Input.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+type Props = {
+  type: string;
+  name: string;
+  placeholder: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+};
+
+const Input = ({ type, name, placeholder, value, onChange }: Props) => {
+  return (
+    <div>
+      <input
+        type={type}
+        name={name}
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+        className="w-full border border-gray-300 rounded-xl focus:ring-1 focus:ring-blue-500 outline-none text-sm sm:text-md md:text-lg font-semibold py-1 px-2 sm:py-1.5 sm:px-3 md:py-2 md:px-4"
+      />
+    </div>
+  );
+};
+
+export default Input;


### PR DESCRIPTION
This PR implements the Sign-up page for the application with the following features:

- Responsive layout for different screen sizes using Tailwind CSS.
- Reusable Button and Input components to standardize UI across the app.
- "Continue with Google" button integrated (UI only).
- Conditional rendering for the password input (only shows if email is entered).
- Navigation links for signing in.

No backend functionality is implemented yet; form submission logs form data to the console.
