### PR TITLE
feat: create Users, Chats, and Chat tables

### DIFF
--- a/backend/db/createTables.ts
+++ b/backend/db/createTables.ts
@@ -1,0 +1,38 @@
+import { connectDB } from './connectDB';
+
+const createTables = async () => {
+  try {
+    await connectDB.query(
+      `CREATE TABLE IF NOT EXISTS Users(
+        userId int AUTO_INCREMENT PRIMARY KEY,
+        email VARCHAR(255),
+        password VARCHAR(255)
+        )`
+    );
+    await connectDB.query(
+      `CREATE TABLE IF NOT EXISTS Chats (
+      chatId int AUTO_INCREMENT PRIMARY KEY, 
+      title VARCHAR(255), 
+      userId int,
+      createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (userId) references Users(userId)
+      )`
+    );
+
+    await connectDB.query(
+      `CREATE TABLE IF NOT EXISTS Chat(
+            messageId int AUTO_INCREMENT PRIMARY KEY,
+            role VARCHAR(255),
+            content TEXT,
+            chatId int,
+            createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (chatId) references Chats(chatId)
+        )`
+    );
+    console.log('table is created');
+  } catch (error: any) {
+    console.log(error.message);
+  }
+};
+
+createTables();

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "scripts": {
     "start": "nodemon app.ts",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "create-tables": "ts-node db/createTables.ts"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
- Added a TypeScript script to create three tables in MySQL:

  1. Users – stores user emails and hashed passwords.
  2. Chats – stores chat sessions, references Users.
  3. Chat – stores individual messages, references Chats.

- Includes AUTO_INCREMENT primary keys and foreign key relationships.
- createdAt timestamps are automatically set.
- Safe to run multiple times (IF NOT EXISTS prevents duplicate tables).