### PR TITLE
test(auth): add unit test for missing JWT secret

### DIFF
--- a/backend/middlewares/authentication.test.ts
+++ b/backend/middlewares/authentication.test.ts
@@ -44,7 +44,32 @@ describe('tests for authentication middleware', () => {
     expect(fakeRes.json).toHaveBeenCalledWith({ msg: 'bad request' });
     expect(fakeNext).not.toHaveBeenCalled();
   });
-  test('should return 401 if authorization header doesnt start with Bearer', () => {});
-  test('should return 500 if jwt token secret is not set', () => {});
+  test('should return 401 if authorization header doesnt start with Bearer', () => {
+    const fakeReq: any = {
+        headers: {
+            authorization: '123'
+        }
+    }
+    authentication()(fakeReq, fakeRes, fakeNext);
+    expect(fakeRes.status).toHaveBeenCalledWith(401)
+    expect(fakeRes.json).toHaveBeenCalledWith({ msg: 'bad request' });
+    expect(fakeNext).not.toHaveBeenCalled();
+});
+  test('should return 500 if jwt token secret is not set', () => {
+    const secret = process.env.JWT_SECRET;
+    delete process.env.JWT_SECRET;
+
+    const fakeReq: any = {
+       headers: {
+        authorization: 'Bearer 123'
+       }
+    }
+
+    authentication()(fakeReq, fakeRes, fakeNext)
+    expect(fakeRes.status).toHaveBeenCalledWith(500)
+    expect(fakeRes.json).toHaveBeenCalledWith({msg: 'jwt secret not set'})
+    expect(fakeNext).not.toHaveBeenCalled();
+    process.env.JWT_SECRET = secret;
+  });
   test('should return 401 if token is invalid or expired', () => {});
 });


### PR DESCRIPTION
# Add unit test for authentication middleware when JWT secret is missing

## Summary
This PR adds a unit test to ensure the `authentication` middleware returns a `500` error when `JWT_SECRET` is not defined in the environment variables.

## Why
Covers an important edge case where the JWT secret is missing, ensuring the middleware fails safely and does not proceed to the next middleware.

## What’s covered
- Returns HTTP `500` status code
- Sends appropriate error message `{ msg: 'jwt secret not set' }`
- Does not call `next()` when `JWT_SECRET` is missing

## Notes
- No production code changes were made.
- The test restores the original environment variable after execution to avoid side effects.
