### PR TITLE
test(authentication): add unit test for invalid or expired JWT token

### DIFF
--- a/backend/middlewares/authentication.test.ts
+++ b/backend/middlewares/authentication.test.ts
@@ -71,5 +71,22 @@ describe('tests for authentication middleware', () => {
     expect(fakeNext).not.toHaveBeenCalled();
     process.env.JWT_SECRET = secret;
   });
-  test('should return 401 if token is invalid or expired', () => {});
+  test('should return 401 if token is invalid or expired', () => {
+    const fakeReq: any = {
+      headers: {
+        authorization: 'Bearer 123'
+      }
+    }
+
+    jwtVerify.mockImplementation(() => {
+      throw new Error('invalid token')
+    });
+    authentication()(fakeReq, fakeRes, fakeNext) 
+
+    expect(fakeRes.status).toHaveBeenCalledWith(401)
+    expect(fakeRes.json).toHaveBeenCalledWith({
+      msg: 'Invalid or expired token',
+    });
+    expect(fakeNext).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
# Add unit test for authentication middleware handling invalid/expired token

## Summary
This PR adds a unit test to ensure the `authentication` middleware returns a `401` error when the provided JWT token is invalid or expired.

## Why
Covers an important error handling scenario where a user provides an invalid or expired token. Ensures the middleware fails safely and does not proceed to the next middleware.

## What’s covered
- Returns HTTP `401` status code
- Sends the correct error message: `{ msg: 'Invalid or expired token' }`
- Ensures `next()` is **not** called when the token is invalid

## Notes
- No production code changes were made.
- Uses a mock implementation of `jwt.verify` to throw an error, simulating an invalid or expired token.
